### PR TITLE
Add MoleculeViewModel

### DIFF
--- a/app/src/main/kotlin/social/plasma/ui/base/MoleculeViewModel.kt
+++ b/app/src/main/kotlin/social/plasma/ui/base/MoleculeViewModel.kt
@@ -1,0 +1,26 @@
+package social.plasma.ui.base
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.cash.molecule.AndroidUiDispatcher
+import app.cash.molecule.RecompositionClock
+import app.cash.molecule.launchMolecule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+
+abstract class MoleculeViewModel<S>(
+    private val recompositionClock: RecompositionClock,
+) : ViewModel() {
+
+    private val moleculeScope =
+        CoroutineScope(viewModelScope.coroutineContext + AndroidUiDispatcher.Main)
+
+    // TODO add some kind of event flow hookup
+    fun uiState(): StateFlow<S> = moleculeScope.launchMolecule(recompositionClock) {
+        models()
+    }
+
+    @Composable
+    protected abstract fun models(): S
+}

--- a/app/src/main/kotlin/social/plasma/ui/feed/Feed.kt
+++ b/app/src/main/kotlin/social/plasma/ui/feed/Feed.kt
@@ -23,7 +23,7 @@ fun Feed(
     viewModel: FeedViewModel = hiltViewModel(),
     onNavigateToProfile: (PubKey) -> Unit,
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState().collectAsState()
 
     FeedContent(
         modifier = modifier,

--- a/app/src/main/kotlin/social/plasma/ui/feed/FeedViewModel.kt
+++ b/app/src/main/kotlin/social/plasma/ui/feed/FeedViewModel.kt
@@ -1,5 +1,6 @@
 package social.plasma.ui.feed
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -14,21 +15,21 @@ import kotlinx.coroutines.flow.StateFlow
 import social.plasma.models.Note
 import social.plasma.models.PubKey
 import social.plasma.repository.NoteRepository
+import social.plasma.ui.base.MoleculeViewModel
 import social.plasma.ui.components.NoteCardUiModel
 import javax.inject.Inject
 
 @HiltViewModel
 class FeedViewModel @Inject constructor(
     recompositionClock: RecompositionClock,
-    noteRepository: NoteRepository,
-) : ViewModel() {
-    private val moleculeScope =
-        CoroutineScope(viewModelScope.coroutineContext + AndroidUiDispatcher.Main)
+    private val noteRepository: NoteRepository,
+) : MoleculeViewModel<FeedUiState>(recompositionClock) {
 
-    val uiState: StateFlow<FeedUiState> = moleculeScope.launchMolecule(recompositionClock) {
+    @Composable
+    override fun models(): FeedUiState {
         val noteList by remember { noteRepository.observeNotes() }.collectAsState(initial = null)
 
-        noteList?.let { notes ->
+        return noteList?.let { notes ->
             val feedCardList = notes.map { it.toFeedUiModel() }
             FeedUiState.Loaded(feedCardList)
         } ?: FeedUiState.Loading


### PR DESCRIPTION
Adds a simple base ViewModel for anything using Molecule so that we're not needing to define the scope + launch the moleculeFlow for each ViewModel