### PR TITLE
Add new `ViewModelWithNavigatorFactory` bindings

### DIFF
--- a/app/src/main/kotlin/social/plasma/di/ViewModelClassKey.kt
+++ b/app/src/main/kotlin/social/plasma/di/ViewModelClassKey.kt
@@ -1,0 +1,10 @@
+package social.plasma.di
+
+import androidx.lifecycle.ViewModel
+import dagger.MapKey
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER)
+@Retention(value = AnnotationRetention.RUNTIME)
+@MapKey
+internal annotation class ViewModelClassKey(val value: KClass<out ViewModel>)

--- a/app/src/main/kotlin/social/plasma/di/ViewModelFactoryEntryPoint.kt
+++ b/app/src/main/kotlin/social/plasma/di/ViewModelFactoryEntryPoint.kt
@@ -1,12 +1,14 @@
 package social.plasma.di
 
+import androidx.lifecycle.ViewModel
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
-import social.plasma.ui.post.PostViewModel
+import social.plasma.ui.base.ViewModelWithNavigatorFactory
 
 @EntryPoint
 @InstallIn(ActivityComponent::class)
 interface ViewModelFactoryEntryPoint {
-    fun postViewModelFactory(): PostViewModel.Factory
+
+    fun navigatorViewModelFactoryMap(): Map<Class<out ViewModel>, @JvmSuppressWildcards ViewModelWithNavigatorFactory<*>>
 }

--- a/app/src/main/kotlin/social/plasma/di/ViewModelModule.kt
+++ b/app/src/main/kotlin/social/plasma/di/ViewModelModule.kt
@@ -1,0 +1,19 @@
+package social.plasma.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import dagger.multibindings.IntoMap
+import social.plasma.ui.base.ViewModelWithNavigatorFactory
+import social.plasma.ui.post.PostViewModel
+
+@Module
+@InstallIn(ActivityComponent::class)
+abstract class ViewModelModule {
+
+    @Binds
+    @IntoMap
+    @ViewModelClassKey(PostViewModel::class)
+    abstract fun bindsPostViewModelFactory(factory: PostViewModel.Factory): ViewModelWithNavigatorFactory<*>
+}

--- a/app/src/main/kotlin/social/plasma/ui/base/ViewModelWithNavigatorFactory.kt
+++ b/app/src/main/kotlin/social/plasma/ui/base/ViewModelWithNavigatorFactory.kt
@@ -1,0 +1,9 @@
+package social.plasma.ui.base
+
+import androidx.lifecycle.ViewModel
+import social.plasma.ui.navigation.Navigator
+
+interface ViewModelWithNavigatorFactory<out VM : ViewModel> {
+
+    fun create(navigator: Navigator): VM
+}

--- a/app/src/main/kotlin/social/plasma/ui/base/viewModelWithNavigator.kt
+++ b/app/src/main/kotlin/social/plasma/ui/base/viewModelWithNavigator.kt
@@ -1,4 +1,4 @@
-package social.plasma.ui.post
+package social.plasma.ui.base
 
 import android.app.Activity
 import androidx.compose.runtime.Composable
@@ -11,15 +11,18 @@ import social.plasma.di.ViewModelFactoryEntryPoint
 import social.plasma.ui.navigation.Navigator
 
 @Composable
-fun postViewModel(navigator: Navigator): PostViewModel {
-    val factory = EntryPointAccessors.fromActivity(
+inline fun <reified VM : ViewModel> viewModelWithNavigator(navigator: Navigator): VM {
+    val map = EntryPointAccessors.fromActivity(
         LocalContext.current as Activity,
         ViewModelFactoryEntryPoint::class.java,
-    ).postViewModelFactory()
+    ).navigatorViewModelFactoryMap()
 
     return viewModel(
         factory = object : ViewModelProvider.Factory {
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                val factory = requireNotNull(map[VM::class.java]) {
+                    "ViewModelWithNavigatorFactory not found for class ${VM::class.java}"
+                }
                 return factory.create(navigator) as T
             }
         },

--- a/app/src/main/kotlin/social/plasma/ui/navigation/Navigation.kt
+++ b/app/src/main/kotlin/social/plasma/ui/navigation/Navigation.kt
@@ -14,10 +14,11 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import social.plasma.R
 import social.plasma.ui.ThreadList
+import social.plasma.ui.base.viewModelWithNavigator
 import social.plasma.ui.home.HomeScreen
 import social.plasma.ui.notifications.NotificationsScreen
 import social.plasma.ui.post.Post
-import social.plasma.ui.post.postViewModel
+import social.plasma.ui.post.PostViewModel
 import social.plasma.ui.profile.Profile
 
 @Composable
@@ -91,7 +92,7 @@ fun Navigation(
         }
 
         composable(Screen.PostNote.route) {
-            val viewModel = postViewModel(navigator = NavControllerNavigator(navHostController))
+            val viewModel = viewModelWithNavigator<PostViewModel>(navigator = NavControllerNavigator(navHostController))
             val state by viewModel.uiState().collectAsState()
             Post(
                 state = state,

--- a/app/src/main/kotlin/social/plasma/ui/post/PostViewModel.kt
+++ b/app/src/main/kotlin/social/plasma/ui/post/PostViewModel.kt
@@ -10,6 +10,7 @@ import dagger.assisted.AssistedInject
 import kotlinx.coroutines.launch
 import social.plasma.repository.NoteRepository
 import social.plasma.ui.base.MoleculeViewModel
+import social.plasma.ui.base.ViewModelWithNavigatorFactory
 import social.plasma.ui.navigation.Navigator
 
 class PostViewModel @AssistedInject constructor(
@@ -37,7 +38,7 @@ class PostViewModel @AssistedInject constructor(
     }
 
     @AssistedFactory
-    interface Factory {
-        fun create(navigator: Navigator): PostViewModel
+    interface Factory : ViewModelWithNavigatorFactory<PostViewModel> {
+        override fun create(navigator: Navigator): PostViewModel
     }
 }


### PR DESCRIPTION
Allows for a more generic way to get references to ViewModels in Compose. The `@AssistedFactory` of the ViewModel should extend ViewModelWithNavigatorFactory and add a binding for it to the ViewModelModule, then you should be able to use the new viewModelWithNavigator extension to create the ViewModel and provide the navigator instance.