### PR TITLE
Reliably start channels.

### DIFF
--- a/nostr/build.gradle.kts
+++ b/nostr/build.gradle.kts
@@ -124,5 +124,4 @@ val stopContainer by tasks.creating(DockerStopContainer::class) {
 
 tasks.withType<Test>().configureEach {
     dependsOn(startContainer)
-    finalizedBy(stopContainer)
 }

--- a/nostr/src/main/kotlin/social/plasma/nostr/relay/Relay.kt
+++ b/nostr/src/main/kotlin/social/plasma/nostr/relay/Relay.kt
@@ -8,7 +8,7 @@ import social.plasma.nostr.relay.message.RelayMessage.EventRelayMessage
 interface Relay {
     val connectionStatus: Flow<RelayStatus>
 
-    fun connect()
+    suspend fun connect()
 
     fun disconnect()
 

--- a/nostr/src/main/kotlin/social/plasma/nostr/relay/RelayImpl.kt
+++ b/nostr/src/main/kotlin/social/plasma/nostr/relay/RelayImpl.kt
@@ -3,19 +3,12 @@ package social.plasma.nostr.relay
 import com.tinder.scarlet.WebSocket
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.filterNot
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
-import social.plasma.nostr.relay.message.ClientMessage.EventMessage
-import social.plasma.nostr.relay.message.ClientMessage.SubscribeMessage
-import social.plasma.nostr.relay.message.ClientMessage.UnsubscribeMessage
+import social.plasma.nostr.relay.message.ClientMessage
+import social.plasma.nostr.relay.message.ClientMessage.*
 import social.plasma.nostr.relay.message.RelayMessage
 import timber.log.Timber
 import java.util.concurrent.atomic.AtomicReference
@@ -35,6 +28,8 @@ class RelayImpl(
             .map { Relay.RelayStatus(url, it.toStatus()) }
 
     private val relayMessages = service.relayMessageFlow()
+    private val pendingSendEvents = MutableSharedFlow<ClientMessage>()
+    private val status = MutableStateFlow<Relay.Status?>(null)
 
     private val subscriptions: AtomicReference<Set<SubscribeMessage>> =
         AtomicReference(setOf())
@@ -43,7 +38,9 @@ class RelayImpl(
     override fun subscribe(subscribeMessage: SubscribeMessage): Flow<RelayMessage.EventRelayMessage> {
         subscriptions.getAndUpdate { it.plus(subscribeMessage) }
 
-        service.sendSubscribe(subscribeMessage)
+        if (status.value == Relay.Status.Connected) service.sendSubscribe(subscribeMessage)
+        else scope.launch { pendingSendEvents.emit(subscribeMessage) }
+
         logger.d("adding sub %s", subscribeMessage)
         logger.d("sub count %s", subscriptions.get().count())
 
@@ -57,8 +54,8 @@ class RelayImpl(
     }
 
     override suspend fun send(event: EventMessage) {
-        logger.d("Sending new event: $event")
-        service.sendEvent(event)
+        if (status.value == Relay.Status.Connected) service.sendEvent(event)
+        else pendingSendEvents.emit(event)
     }
 
     private fun unsubscribe(request: UnsubscribeMessage) {
@@ -70,11 +67,23 @@ class RelayImpl(
         logger.d("sub count %s", subscriptions.get().count())
     }
 
-    override fun connect() {
+    private suspend fun publishPendingEvents() {
+        pendingSendEvents.collect {
+            when (it) {
+                is EventMessage -> service.sendEvent(it)
+                is SubscribeMessage -> service.sendSubscribe(it)
+                else -> {}
+            }
+        }
+    }
+
+    override suspend fun connect() {
         connectionLoop = connectionStatus.distinctUntilChanged().onEach {
+            status.emit(it.status)
             when (it.status) {
                 is Relay.Status.Connected -> {
                     logger.d("connection opened: %s", it)
+                    publishPendingEvents()
                     reSubscribeAll() // TODO - do we need to resubscribe on each reconnect?
                 }
 
@@ -91,7 +100,7 @@ class RelayImpl(
                 }
             }
         }.launchIn(scope)
-        logger.d("Launched")
+        while (status.value != Relay.Status.Connected) delay(100L)
     }
 
     override fun disconnect() {

--- a/nostr/src/main/kotlin/social/plasma/nostr/relay/RelayImpl.kt
+++ b/nostr/src/main/kotlin/social/plasma/nostr/relay/RelayImpl.kt
@@ -28,7 +28,7 @@ class RelayImpl(
             .map { Relay.RelayStatus(url, it.toStatus()) }
 
     private val relayMessages = service.relayMessageFlow()
-    private val pendingSendEvents = MutableSharedFlow<ClientMessage>()
+    private val pendingSendEvents = MutableSharedFlow<ClientMessage>(extraBufferCapacity = 1_000)
     private val status = MutableStateFlow<Relay.Status?>(null)
 
     private val subscriptions: AtomicReference<Set<SubscribeMessage>> =

--- a/nostr/src/main/kotlin/social/plasma/nostr/relay/Relays.kt
+++ b/nostr/src/main/kotlin/social/plasma/nostr/relay/Relays.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import social.plasma.nostr.relay.message.ClientMessage.EventMessage
 import social.plasma.nostr.relay.message.ClientMessage.SubscribeMessage
@@ -27,13 +28,13 @@ class Relays @Inject constructor(
     private val relayList: List<Relay> = relayUrlList.map { createRelay(it, scope) }
 
     init {
-        connect()
+        scope.launch { connect() }
     }
 
     override val connectionStatus: Flow<Relay.RelayStatus>
         get() = relayList.map { it.connectionStatus }.merge()
 
-    override fun connect() {
+    override suspend fun connect() {
         relayList.forEach {
             it.connect()
         }

--- a/nostr/src/test/kotlin/social/plasma/nostr/relay/RealRelayTest.kt
+++ b/nostr/src/test/kotlin/social/plasma/nostr/relay/RealRelayTest.kt
@@ -5,73 +5,54 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.next
+import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.stringPattern
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import social.plasma.crypto.KeyGenerator
+import social.plasma.crypto.KeyPair
 import social.plasma.nostr.BuildingBlocks.JemPubKey
 import social.plasma.nostr.BuildingBlocks.moshi
 import social.plasma.nostr.BuildingBlocks.scarlet
+import social.plasma.nostr.BuildingBlocks.testRelay
+import social.plasma.nostr.models.Event
 import social.plasma.nostr.models.UserMetaData
+import social.plasma.nostr.relay.message.ClientMessage
+import social.plasma.nostr.relay.message.ClientMessage.EventMessage
 import social.plasma.nostr.relay.message.ClientMessage.SubscribeMessage
 import social.plasma.nostr.relay.message.Filter
+import java.time.Instant
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class RealRelayTest : StringSpec({
 
-/*
-    val client = OkHttpClient.Builder()
-        .addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.NONE))
-        .build()
-
-    // TODO - a deterministic test using a mock webserver
-    val relayUrl = "wss://brb.io"
-
-    "can get events from a relay" {
-        runTest {
-            val relay = RelayImpl(
-                relayUrl,
-                scarlet
-                    .webSocketFactory(client.newWebSocketFactory(relayUrl))
-                    .build()
-                    .create(),
-                this
-            )
-            relay.connect()
-            val events = relay.subscribe(SubscribeMessage(Filter.contactList(JemPubKey)))
-            events.first().event.content shouldContain "nostr.satsophone.tk"
-            relay.disconnect()
-        }
-    }
-
-    "can subscribe to a relay" {
-        val relay = RelayImpl(
-            relayUrl,
-            scarlet
-                .webSocketFactory(client.newWebSocketFactory(relayUrl))
-                .build()
-                .create(),
-            this
-        )
+    "can write notes to a relay" {
+        val relay = testRelay(this)
+        val text = Arb.stringPattern("[a-zA-Z0-9]+").next()
         relay.connect()
-        relay.subscribe(SubscribeMessage(Filter.contactList(JemPubKey)))
-
-        val event = relay.subscribe(
-            SubscribeMessage(
-                Filter.userMetaData("67e4027f797f15c8a89de7a03a07ddb0efe63985fa6716f8b3c742a008ca0be7")
+        val key = KeyGenerator().generateKey()
+        val notes = relay.subscribe(SubscribeMessage(Filter.userNotes(pubKey = key.pub.hex())))
+        val message = EventMessage(
+            Event.createEvent(
+                key.pub,
+                key.sec,
+                Instant.now(),
+                Event.Kind.Note,
+                emptyList(), // TODO - send the right tags
+                text
             )
-        ).filter { it.event.content.contains("heastmined") }
-            .first()
+        )
 
-
-        event should {
-            moshi.adapter(UserMetaData::class.java)
-                .fromJson(it.event.content)?.name shouldBe "heastmined"
+        relay.send(message)
+        with(notes.first().event) {
+            content shouldBe text
+            pubKey shouldBe key.pub
         }
-
         relay.disconnect()
     }
-*/
 })


### PR DESCRIPTION
By not returning from the connect method until the connect message has been received, we can ensure that messages sent from the client are not sent prematurely
Also introduces keypair generation and the a test to use the local docker relay instance.