### PR TITLE
Use the Nostrino version of PubKey

### DIFF
--- a/app/src/androidTest/kotlin/social/plasma/ui/KeyConversionTest.kt
+++ b/app/src/androidTest/kotlin/social/plasma/ui/KeyConversionTest.kt
@@ -4,7 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.models.crypto.Bech32.bechToBytes
 import social.plasma.models.crypto.Bech32.pubkeyCreate
 

--- a/common/ui/build.gradle.kts
+++ b/common/ui/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     implementation(libs.exoplayer.core)
     implementation(libs.exoplayer.ui)
 
+    implementation(libs.nostrino)
+
     implementation(libs.okhttp.core)
     implementation(libs.timber)
     implementation(libs.touchimageview)

--- a/common/ui/src/main/kotlin/social/plasma/ui/components/richtext/RichText.kt
+++ b/common/ui/src/main/kotlin/social/plasma/ui/components/richtext/RichText.kt
@@ -36,11 +36,12 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastAny
+import app.cash.nostrino.crypto.PubKey
+import okio.ByteString.Companion.decodeHex
 import social.plasma.models.Mention
 import social.plasma.models.NoteId
 import social.plasma.models.NoteMention
 import social.plasma.models.ProfileMention
-import social.plasma.models.PubKey
 import kotlin.math.ceil
 
 
@@ -73,7 +74,7 @@ fun RichText(
     fun handleClick(tag: String, item: String) {
         when (tag) {
             RichTextTag.URL -> uriHandler.openUri(item)
-            RichTextTag.PROFILE -> onMentionClick(ProfileMention(pubkey = PubKey(item), text = ""))
+            RichTextTag.PROFILE -> onMentionClick(ProfileMention(pubkey = PubKey(item.decodeHex()), text = ""))
             RichTextTag.NOTE -> onMentionClick(NoteMention(noteId = NoteId(item), text = ""))
             else -> error("Unsupported tag: $tag")
         }

--- a/common/ui/src/main/kotlin/social/plasma/ui/components/richtext/RichTextParser.kt
+++ b/common/ui/src/main/kotlin/social/plasma/ui/components/richtext/RichTextParser.kt
@@ -15,7 +15,7 @@ class RichTextParser constructor(
     private val linkColor: Color,
 ) {
     private val urlRegex = Regex("(https?://\\S+)")
-    private val mentionRegex = Regex("#\\[[0-9]+]")
+    private val mentionRegex = Regex("#\\[\\d+]")
 
     /**
      * Builds an annotated string using the note's mentions.
@@ -72,7 +72,7 @@ class RichTextParser constructor(
             mentions[key]?.let { mention ->
                 when (mention) {
                     is ProfileMention -> withProfileMention(
-                        pubkey = mention.pubkey.hex,
+                        pubkey = mention.pubkey.key.hex(),
                         color = linkColor,
                     ) {
                         append(mention.text)

--- a/common/ui/src/test/java/social/plasma/ui/components/RichTextParserTest.kt
+++ b/common/ui/src/test/java/social/plasma/ui/components/RichTextParserTest.kt
@@ -8,7 +8,8 @@ import org.junit.Test
 import social.plasma.models.NoteId
 import social.plasma.models.NoteMention
 import social.plasma.models.ProfileMention
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
+import app.cash.nostrino.crypto.SecKeyGenerator
 import social.plasma.ui.components.richtext.RichTextParser
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -31,18 +32,26 @@ class RichTextParserTest {
     }
 
     @Test
-    fun `note with multiline profile mentions`() = runTest {
-        val plainText =
-            "Some text \n\nhttps://apidocs.imgur.com/\n\n#[0]\n#[1] \n#[2] \n#[3] \n#[4]"
+    fun `note with multiline profile mentions`() {
+        runTest {
+            val plainText =
+                "Some text \n\nhttps://apidocs.imgur.com/\n\n#[0]\n#[1] \n#[2]"
 
-        val mentions = (0..4).associateWith {
-            ProfileMention(text = "@note$it", pubkey = PubKey("note$it"))
+            val keys = listOf(
+                PubKey.parse("npub1mm90r3fkz436p4jgtkcqdy4uvelgx3xru6ej242ktx096flmmhjsfqrwg0"),
+                PubKey.parse("npub1zvrwm4n0rk3hftwyzl8csjaulatuvwvk2c3kc8u89mssgq7qrvks5zvf63"),
+                PubKey.parse("npub1jcgyf7tcshfkc48w40g2s3769h0uw79mnx73hspwcpdgy049rm5spf50ps"),
+            )
+
+            val mentions = keys.mapIndexed { i, key ->
+                i to ProfileMention(text = "@note$i", pubkey = key)
+            }.toMap()
+
+            val result = parser.parse(plainText, mentions)
+
+            assertThat(result.text)
+                .isEqualTo("Some text \n\nhttps://apidocs.imgur.com/\n\n@note0\n@note1 \n@note2")
         }
-
-        val result = parser.parse(plainText, mentions)
-
-        assertThat(result.text)
-            .isEqualTo("Some text \n\nhttps://apidocs.imgur.com/\n\n@note0\n@note1 \n@note2 \n@note3 \n@note4")
     }
 
     @Test
@@ -51,8 +60,8 @@ class RichTextParserTest {
             "Hey #[0], have you considered collaborating with #[1]?"
 
         val mentions = mapOf(
-            0 to ProfileMention("@joe", PubKey("joekey")),
-            1 to ProfileMention("@will", PubKey("Will"))
+            0 to ProfileMention("@joe", PubKey.parse("npub1mm90r3fkz436p4jgtkcqdy4uvelgx3xru6ej242ktx096flmmhjsfqrwg0")),
+            1 to ProfileMention("@will", PubKey.parse("npub1jcgyf7tcshfkc48w40g2s3769h0uw79mnx73hspwcpdgy049rm5spf50ps"))
         )
 
         val result = parser.parse(plainText, mentions)
@@ -68,8 +77,8 @@ class RichTextParserTest {
             "Best people to follow:#[0] and #[1]."
 
         val mentions = mapOf(
-            0 to ProfileMention("@joe", PubKey("joekey")),
-            1 to ProfileMention("@will", PubKey("Will"))
+            0 to ProfileMention("@joe", PubKey.parse("npub1felyu03mh8xdszx927cyvgyf9yp83feyyug4505aa8cma5t6g9vql86w95")),
+            1 to ProfileMention("@will", PubKey.parse("npub1tjkc9jycaenqzdc3j3wkslmaj4ylv3dqzxzx0khz7h38f3vc6mls4ys9w3"))
         )
 
         val result = parser.parse(plainText, mentions)

--- a/data/models/src/main/kotlin/social/plasma/models/Mention.kt
+++ b/data/models/src/main/kotlin/social/plasma/models/Mention.kt
@@ -1,5 +1,6 @@
 package social.plasma.models
 
+import app.cash.nostrino.crypto.PubKey
 sealed class Mention {
     abstract val text: String
 }

--- a/data/models/src/main/kotlin/social/plasma/models/PubKey.kt
+++ b/data/models/src/main/kotlin/social/plasma/models/PubKey.kt
@@ -1,26 +1,6 @@
-package social.plasma.models
+import app.cash.nostrino.crypto.PubKey
 
-import fr.acinq.secp256k1.Hex
-import okio.ByteString.Companion.decodeHex
-import social.plasma.models.crypto.Bech32.toBech32
-
-data class PubKey(
-    val hex: String,
-) {
-    val bech32 by lazy {
-        hex.decodeHex().toByteArray().toBech32("npub")
-    }
-
-    val shortBech32 by lazy {
-        with(bech32.drop(5)) {
-            "${take(8)}:${takeLast(8)}"
-        }
-    }
-
-    companion object {
-        fun of(byteArray: ByteArray): PubKey {
-            return PubKey(Hex.encode(byteArray))
-        }
-    }
+// TODO - this has been moved into the next version of Nostrino's PubKey type
+fun PubKey.shortBech32() = with(encoded().drop(5)) {
+    "${take(8)}:${takeLast(8)}"
 }
-

--- a/data/models/src/main/kotlin/social/plasma/models/Tag.kt
+++ b/data/models/src/main/kotlin/social/plasma/models/Tag.kt
@@ -1,5 +1,6 @@
 package social.plasma.models
 
+import app.cash.nostrino.crypto.PubKey
 sealed interface Tag
 data class EventTag(val noteId: NoteId) : Tag
 data class PubKeyTag(val pubKey: PubKey) : Tag

--- a/data/models/src/main/kotlin/social/plasma/models/TagSuggestion.kt
+++ b/data/models/src/main/kotlin/social/plasma/models/TagSuggestion.kt
@@ -1,5 +1,6 @@
 package social.plasma.models
 
+import app.cash.nostrino.crypto.PubKey
 data class TagSuggestion(
     val pubKey: PubKey,
     val imageUrl: String?,

--- a/data/models/src/main/kotlin/social/plasma/models/UserMetadataEntity.kt
+++ b/data/models/src/main/kotlin/social/plasma/models/UserMetadataEntity.kt
@@ -3,6 +3,9 @@ package social.plasma.models
 import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
+import app.cash.nostrino.crypto.PubKey
+import okio.ByteString.Companion.decodeHex
+import shortBech32
 
 @Entity(tableName = "user_metadata")
 data class UserMetadataEntity(
@@ -21,6 +24,6 @@ data class UserMetadataEntity(
     @delegate:Ignore
     val userFacingName: String by lazy {
         displayName?.takeIf { it.isNotBlank() } ?: name?.takeIf { it.isNotBlank() }
-        ?: PubKey(pubkey).shortBech32
+        ?: PubKey(pubkey.decodeHex()).shortBech32()
     }
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
 
     implementation(libs.androidx.paging.common)
     implementation(libs.moshi.core)
+    implementation(libs.nostrino)
     testImplementation(projects.repositories.fakes)
     testImplementation(libs.coroutines.test)
     testImplementation(libs.junit)

--- a/domain/src/main/java/social/plasma/domain/interactors/GetNip5Status.kt
+++ b/domain/src/main/java/social/plasma/domain/interactors/GetNip5Status.kt
@@ -1,9 +1,9 @@
 package social.plasma.domain.interactors
 
+import app.cash.nostrino.crypto.PubKey
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl
 import social.plasma.domain.ResultInteractor
-import social.plasma.models.PubKey
 import social.plasma.shared.repositories.api.Nip5Validator
 import javax.inject.Inject
 import javax.inject.Named
@@ -27,7 +27,7 @@ class GetNip5Status @Inject constructor(
         val name = parts[0]
         val domain = parts[1]
 
-        val pubKeyHex = params.pubKey.hex
+        val pubKeyHex = params.pubKey.key.hex()
         val httpUrl = try {
             HttpUrl.Builder()
                 .scheme("https")

--- a/domain/src/main/java/social/plasma/domain/interactors/GetNoteTagSuggestions.kt
+++ b/domain/src/main/java/social/plasma/domain/interactors/GetNoteTagSuggestions.kt
@@ -1,7 +1,8 @@
 package social.plasma.domain.interactors
 
+import app.cash.nostrino.crypto.PubKey
+import okio.ByteString.Companion.decodeHex
 import social.plasma.domain.ResultInteractor
-import social.plasma.models.PubKey
 import social.plasma.models.TagSuggestion
 import social.plasma.shared.repositories.api.UserMetadataRepository
 import javax.inject.Inject
@@ -24,7 +25,7 @@ class GetNoteTagSuggestions @Inject constructor(
 
             return userEntities.map {
                 TagSuggestion(
-                    pubKey = PubKey(it.pubkey),
+                    pubKey = PubKey(it.pubkey.decodeHex()),
                     imageUrl = it.picture,
                     title = it.userFacingName,
                     nip5Identifier = it.nip05,

--- a/domain/src/main/java/social/plasma/domain/interactors/SyncAllEvents.kt
+++ b/domain/src/main/java/social/plasma/domain/interactors/SyncAllEvents.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import social.plasma.domain.Interactor
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.nostr.relay.Relay
 import social.plasma.nostr.relay.message.ClientMessage
 import social.plasma.nostr.relay.message.Filter
@@ -24,8 +24,8 @@ class SyncAllEvents @Inject constructor(
         val pubkey = params.pubKey
 
         val subscribeMessage = ClientMessage.SubscribeMessage(
-            Filter(authors = setOf(pubkey.hex), since = Instant.EPOCH, limit = 2000),
-            Filter(pTags = setOf(pubkey.hex), limit = 2000)
+            Filter(authors = setOf(pubkey.key.hex()), since = Instant.EPOCH, limit = 2000),
+            Filter(pTags = setOf(pubkey.key.hex()), limit = 2000)
         )
 
         val subscription = relay.subscribe(subscribeMessage).distinctUntilChanged().map { it.event }

--- a/domain/src/main/java/social/plasma/domain/interactors/SyncContactsEvents.kt
+++ b/domain/src/main/java/social/plasma/domain/interactors/SyncContactsEvents.kt
@@ -1,5 +1,6 @@
 package social.plasma.domain.interactors
 
+import app.cash.nostrino.crypto.PubKey
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
@@ -11,7 +12,7 @@ import kotlinx.coroutines.flow.onStart
 import social.plasma.domain.InvokeStatus
 import social.plasma.domain.SubjectInteractor
 import social.plasma.domain.observers.ObserveContacts
-import social.plasma.models.PubKey
+import okio.ByteString.Companion.toByteString
 import social.plasma.nostr.relay.Relay
 import social.plasma.nostr.relay.message.ClientMessage
 import social.plasma.nostr.relay.message.ClientMessage.SubscribeMessage
@@ -32,7 +33,7 @@ class SyncContactsEvents @Inject constructor(
 ) : SubjectInteractor<Unit, Any>() {
 
     override fun createObservable(params: Unit): Flow<Any> {
-        val pubKey = PubKey.of(accountStateRepository.getPublicKey()!!)
+        val pubKey = PubKey(accountStateRepository.getPublicKey()?.toByteString()!!)
 
         return observeContacts.flow.onStart {
             observeContacts(ObserveContacts.Params(pubKey))

--- a/domain/src/main/java/social/plasma/domain/interactors/SyncProfileData.kt
+++ b/domain/src/main/java/social/plasma/domain/interactors/SyncProfileData.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withContext
 import social.plasma.domain.Interactor
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.nostr.relay.Relay
 import social.plasma.nostr.relay.message.ClientMessage
 import social.plasma.nostr.relay.message.Filter
@@ -27,9 +27,9 @@ class SyncProfileData @Inject constructor(
         val pubkey = params.pubKey
 
         val subscribeMessage = ClientMessage.SubscribeMessage(
-            Filter.contactList(pubkey.hex),
-            Filter.userMetaData(pubkey.hex),
-            Filter.userNotes(pubkey.hex),
+            Filter.contactList(pubkey.key.hex()),
+            Filter.userMetaData(pubkey.key.hex()),
+            Filter.userNotes(pubkey.key.hex()),
         )
 
         val subscription = relay.subscribe(subscribeMessage)

--- a/domain/src/main/java/social/plasma/domain/observers/ObserveFollowingCount.kt
+++ b/domain/src/main/java/social/plasma/domain/observers/ObserveFollowingCount.kt
@@ -3,13 +3,13 @@ package social.plasma.domain.observers
 import kotlinx.coroutines.flow.Flow
 import social.plasma.data.daos.ContactsDao
 import social.plasma.domain.SubjectInteractor
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import javax.inject.Inject
 
 class ObserveFollowingCount @Inject constructor(
     private val contactsDao: ContactsDao
 ) : SubjectInteractor<PubKey, Long>() {
     override fun createObservable(params: PubKey): Flow<Long> {
-        return contactsDao.observeFollowingCount(params.hex)
+        return contactsDao.observeFollowingCount(params.key.hex())
     }
 }

--- a/domain/src/main/java/social/plasma/domain/observers/ObserveMyContacts.kt
+++ b/domain/src/main/java/social/plasma/domain/observers/ObserveMyContacts.kt
@@ -4,14 +4,14 @@ import kotlinx.coroutines.flow.Flow
 import social.plasma.data.daos.ContactsDao
 import social.plasma.domain.SubjectInteractor
 import social.plasma.models.ContactEntity
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import javax.inject.Inject
 
 class ObserveContacts @Inject constructor(
     private val contactsDao: ContactsDao,
 ) : SubjectInteractor<ObserveContacts.Params, List<ContactEntity>>() {
     override fun createObservable(params: Params): Flow<List<ContactEntity>> {
-        return contactsDao.observeContacts(params.pubKey.hex)
+        return contactsDao.observeContacts(params.pubKey.key.hex())
     }
 
     data class Params(val pubKey: PubKey)

--- a/domain/src/main/java/social/plasma/domain/observers/ObservePagedProfileFeed.kt
+++ b/domain/src/main/java/social/plasma/domain/observers/ObservePagedProfileFeed.kt
@@ -3,11 +3,11 @@ package social.plasma.domain.observers
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import app.cash.nostrino.crypto.PubKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import social.plasma.domain.PagingInteractor
 import social.plasma.models.NoteWithUser
-import social.plasma.models.PubKey
 import social.plasma.shared.repositories.api.NoteRepository
 import javax.inject.Inject
 

--- a/domain/src/main/java/social/plasma/domain/observers/ObservePagedThreadFeed.kt
+++ b/domain/src/main/java/social/plasma/domain/observers/ObservePagedThreadFeed.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import social.plasma.domain.PagingInteractor
 import social.plasma.models.NoteId
 import social.plasma.models.NoteWithUser
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.shared.repositories.api.NoteRepository
 import javax.inject.Inject
 

--- a/domain/src/main/java/social/plasma/domain/observers/ObserveUserIsInContacts.kt
+++ b/domain/src/main/java/social/plasma/domain/observers/ObserveUserIsInContacts.kt
@@ -3,7 +3,7 @@ package social.plasma.domain.observers
 import kotlinx.coroutines.flow.Flow
 import social.plasma.data.daos.ContactsDao
 import social.plasma.domain.SubjectInteractor
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import javax.inject.Inject
 
 class ObserveUserIsInContacts @Inject constructor(
@@ -13,8 +13,8 @@ class ObserveUserIsInContacts @Inject constructor(
 
     override fun createObservable(params: Params): Flow<Boolean> {
         return contactListDao.observeOwnerFollowsContact(
-            ownerPubKey = params.ownerPubKey.hex,
-            contactPubKey = params.contactPubKey.hex
+            ownerPubKey = params.ownerPubKey.key.hex(),
+            contactPubKey = params.contactPubKey.key.hex()
         )
     }
 }

--- a/domain/src/main/java/social/plasma/domain/observers/ObserveUserMetadata.kt
+++ b/domain/src/main/java/social/plasma/domain/observers/ObserveUserMetadata.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onEach
 import social.plasma.data.daos.UserMetadataDao
 import social.plasma.domain.SubjectInteractor
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.models.UserMetadataEntity
 import javax.inject.Inject
 
@@ -14,7 +14,7 @@ class ObserveUserMetadata @Inject constructor(
 ) : SubjectInteractor<ObserveUserMetadata.Params, UserMetadataEntity?>() {
 
     override fun createObservable(params: Params): Flow<UserMetadataEntity?> {
-        return userMetadataDao.observeUserMetadata(params.pubKey.hex).onEach {
+        return userMetadataDao.observeUserMetadata(params.pubKey.key.hex()).onEach {
             Log.d("@@@", "$it")
         }
     }

--- a/domain/src/test/java/social/plasma/domain/interactors/GetNoteTagSuggestionsTest.kt
+++ b/domain/src/test/java/social/plasma/domain/interactors/GetNoteTagSuggestionsTest.kt
@@ -5,7 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.models.TagSuggestion
 import social.plasma.models.UserMetadataEntity
 import social.plasma.shared.repositories.fakes.FakeUserMetadataRepository
@@ -29,7 +29,7 @@ class GetNoteTagSuggestionsTest {
         ).test {
             assertThat(awaitItem()).containsExactly(
                 TagSuggestion(
-                    pubKey = PubKey(""),
+                    pubKey = PubKey.parse("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"),
                     imageUrl = null,
                     title = "test",
                     nip5Identifier = null
@@ -46,7 +46,7 @@ class GetNoteTagSuggestionsTest {
         getNoteTagSuggestions(GetNoteTagSuggestions.Params("@j", cursorPosition = 2)).test {
             assertThat(awaitItem()).containsExactly(
                 TagSuggestion(
-                    pubKey = PubKey(""),
+                    pubKey = PubKey.parse("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"),
                     imageUrl = null,
                     title = "test",
                     nip5Identifier = null
@@ -69,7 +69,7 @@ class GetNoteTagSuggestionsTest {
         ).test {
             assertThat(awaitItem()).containsExactly(
                 TagSuggestion(
-                    pubKey = PubKey(""),
+                    pubKey = PubKey.parse("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"),
                     imageUrl = null,
                     title = "test",
                     nip5Identifier = null
@@ -120,7 +120,7 @@ class GetNoteTagSuggestionsTest {
         about = null,
         createdAt = null,
         banner = null,
-        pubkey = "",
+        pubkey = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
         website = null,
         lud = null,
         nip05 = null,

--- a/domain/src/test/java/social/plasma/domain/interactors/SendNoteReactionTest.kt
+++ b/domain/src/test/java/social/plasma/domain/interactors/SendNoteReactionTest.kt
@@ -18,7 +18,8 @@ import social.plasma.models.Event
 import social.plasma.models.NoteId
 import social.plasma.models.NoteView
 import social.plasma.models.NoteWithUser
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
+import okio.ByteString.Companion.decodeHex
 import social.plasma.models.crypto.KeyGenerator
 import social.plasma.shared.repositories.fakes.FakeAccountStateRepository
 import social.plasma.shared.repositories.fakes.FakeNoteRepository
@@ -71,7 +72,7 @@ class SendNoteReactionTest {
                 assertThat(pubKey).isEqualTo(myPubKey.toByteString())
                 assertThat(tags).containsExactly(
                     listOf("e", NOTE_ID.hex),
-                    listOf("p", PUBKEY.hex),
+                    listOf("p", PUBKEY.key.hex()),
                 ).inOrder()
             }
 
@@ -97,7 +98,7 @@ class SendNoteReactionTest {
                     listOf("p", "test"),
                     listOf("p", "test2"),
                     listOf("e", NOTE_ID.hex),
-                    listOf("p", PUBKEY.hex),
+                    listOf("p", PUBKEY.key.hex()),
                 ).inOrder()
             }
 
@@ -127,7 +128,7 @@ class SendNoteReactionTest {
 
     private fun createNote(
         id: String = NOTE_ID.hex,
-        pubKey: String = PUBKEY.hex,
+        pubKey: String = PUBKEY.key.hex(),
         isReply: Boolean = false,
         tags: List<List<String>> = emptyList(),
     ) = NoteWithUser(
@@ -159,7 +160,7 @@ class SendNoteReactionTest {
         private val NOTE_ID =
             NoteId("69dac2a7c46835a5c197eab632d262b84b8a017a1226739f08f163b6fede8c74")
         private val PUBKEY =
-            PubKey("12bbde125d610b64f79194eb80478fe33ad95ed34184c7f0577e6214f3266cb0")
+            PubKey("12bbde125d610b64f79194eb80478fe33ad95ed34184c7f0577e6214f3266cb0".decodeHex())
 
     }
 }

--- a/domain/src/test/java/social/plasma/domain/interactors/SendNoteTest.kt
+++ b/domain/src/test/java/social/plasma/domain/interactors/SendNoteTest.kt
@@ -14,7 +14,8 @@ import social.plasma.models.EventTag
 import social.plasma.models.NoteId
 import social.plasma.models.NoteView
 import social.plasma.models.NoteWithUser
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
+import okio.ByteString.Companion.decodeHex
 import social.plasma.models.PubKeyTag
 import social.plasma.shared.repositories.fakes.FakeNoteRepository
 import java.time.Instant
@@ -117,8 +118,8 @@ class SendNoteTest {
     fun `reply to root note that contains mentions`() = runTest {
         val parentNote = createNote(
             tags = listOf(
-                listOf("e", "orginaleventid"),
-                listOf("p", "originalpubkey"),
+                listOf("e", "002036bfff2a9779c840f718d2893ae8978416fdfb648ad929de59b13c78d61f40c6"),
+                listOf("p", "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
             )
         )
 
@@ -132,9 +133,9 @@ class SendNoteTest {
 
             with(noteRepository.sendNoteEvents.awaitItem()) {
                 assertThat(tags).containsExactly(
-                    EventTag(NoteId("orginaleventid")),
+                    EventTag(NoteId("002036bfff2a9779c840f718d2893ae8978416fdfb648ad929de59b13c78d61f40c6")),
                     EventTag(NOTE_ID),
-                    PubKeyTag(PubKey("originalpubkey")),
+                    PubKeyTag(PubKey.parse("npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63q0uf63m")),
                     PubKeyTag(PUBKEY),
                 ).inOrder()
 
@@ -148,11 +149,11 @@ class SendNoteTest {
     fun `reply note that contains mentions`() = runTest {
         val parentNote = createNote(
             tags = listOf(
-                listOf("e", "rootid"),
-                listOf("e", "mentionid"),
-                listOf("e", "replyid"),
-                listOf("p", "somenpub"),
-                listOf("p", "someothernpub"),
+                listOf("e", "1f23d2882d58df3b080b4a2e2cf30165229dfed9bc35b2d53435453aa632d70b"),
+                listOf("e", "00201f23d2882d58df3b080b4a2e2cf30165229dfed9bc35b2d53435453aa632d70b"),
+                listOf("e", "00208e014a1399b4757e8b92b9eb3f343d416ed7631715545e96ca4fe3dd1e294ff4"),
+                listOf("p", "762a3c15c6fa90911bf13d50fc3a29f1663dc1f04b4397a89eef604f622ecd60"),
+                listOf("p", "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
             ),
             isReply = true,
         )
@@ -167,10 +168,10 @@ class SendNoteTest {
 
             with(noteRepository.sendNoteEvents.awaitItem()) {
                 assertThat(tags).containsExactly(
-                    EventTag(NoteId("rootid")),
+                    EventTag(NoteId("1f23d2882d58df3b080b4a2e2cf30165229dfed9bc35b2d53435453aa632d70b")),
                     EventTag(NOTE_ID),
-                    PubKeyTag(PubKey("somenpub")),
-                    PubKeyTag(PubKey("someothernpub")),
+                    PubKeyTag(PubKey.parse("npub1wc4rc9wxl2gfzxl384g0cw3f79nrms0sfdpe02y7aasy7c3we4sqd0qywr")),
+                    PubKeyTag(PubKey.parse("npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63q0uf63m")),
                     PubKeyTag(PUBKEY),
                 ).inOrder()
 
@@ -183,7 +184,7 @@ class SendNoteTest {
 
     private fun createNote(
         id: String = NOTE_ID.hex,
-        pubKey: String = PUBKEY.hex,
+        pubKey: String = PUBKEY.key.hex(),
         isReply: Boolean = false,
         tags: List<List<String>> = emptyList(),
     ) = NoteWithUser(
@@ -208,7 +209,7 @@ class SendNoteTest {
         private val NOTE_ID =
             NoteId("69dac2a7c46835a5c197eab632d262b84b8a017a1226739f08f163b6fede8c74")
         private val PUBKEY =
-            PubKey("12bbde125d610b64f79194eb80478fe33ad95ed34184c7f0577e6214f3266cb0")
+            PubKey("12bbde125d610b64f79194eb80478fe33ad95ed34184c7f0577e6214f3266cb0".decodeHex())
 
         private const val NPUB = "npub1z2aauyjavy9kfau3jn4cq3u0uvadjhkngxzv0uzh0e3pfuexdjcql0pyy7"
 

--- a/features/feeds/presenters/build.gradle.kts
+++ b/features/feeds/presenters/build.gradle.kts
@@ -50,19 +50,19 @@ android {
 }
 
 dependencies {
-    implementation(projects.domain)
-    implementation(projects.data.daos)
-    implementation(projects.features.feeds.screens)
-    implementation(projects.features.profile.screens)
-    implementation(projects.features.posting.screens)
-    implementation(projects.repositories.api)
     implementation(projects.common.utils.api)
-    implementation(projects.domain)
+    implementation(projects.data.daos)
     implementation(projects.data.models)
+    implementation(projects.domain)
+    implementation(projects.features.feeds.screens)
+    implementation(projects.features.posting.screens)
+    implementation(projects.features.profile.screens)
+    implementation(projects.repositories.api)
 
     implementation(libs.androidx.paging.common)
     implementation(libs.circuit.core)
     implementation(libs.circuit.retained)
+    implementation(libs.nostrino)
     implementation(libs.timber)
 
     implementation(libs.hilt.android)

--- a/features/feeds/presenters/src/main/java/social/plasma/feeds/presenters/feed/FeedPresenter.kt
+++ b/features/feeds/presenters/src/main/java/social/plasma/feeds/presenters/feed/FeedPresenter.kt
@@ -72,7 +72,7 @@ class FeedPresenter @AssistedInject constructor(
                 }
 
                 is FeedUiEvent.OnProfileClick -> {
-                    navigator.goTo(ProfileScreen(pubKeyHex = event.pubKey.hex))
+                    navigator.goTo(ProfileScreen(pubKeyHex = event.pubKey.key.hex()))
                 }
 
                 is FeedUiEvent.OnNoteDisplayed -> {

--- a/features/feeds/screens/build.gradle.kts
+++ b/features/feeds/screens/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     api(projects.data.opengraph)
     implementation(libs.circuit.core)
     implementation(libs.compose.runtime)
+    implementation(libs.nostrino)
 
     implementation(libs.androidx.paging.runtime)
 }

--- a/features/feeds/screens/src/main/java/social/plasma/features/feeds/screens/feed/FeedUiEvent.kt
+++ b/features/feeds/screens/src/main/java/social/plasma/features/feeds/screens/feed/FeedUiEvent.kt
@@ -2,7 +2,7 @@ package social.plasma.features.feeds.screens.feed
 
 import com.slack.circuit.CircuitUiEvent
 import social.plasma.models.NoteId
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 
 sealed interface FeedUiEvent : CircuitUiEvent {
     data class OnNoteClick(val noteId: NoteId) : FeedUiEvent

--- a/features/feeds/screens/src/main/java/social/plasma/features/feeds/screens/feed/FeedUiState.kt
+++ b/features/feeds/screens/src/main/java/social/plasma/features/feeds/screens/feed/FeedUiState.kt
@@ -4,8 +4,8 @@ import androidx.paging.PagingData
 import com.slack.circuit.CircuitUiState
 import kotlinx.coroutines.flow.Flow
 import social.plasma.models.Mention
-import social.plasma.models.PubKey
 import social.plasma.opengraph.OpenGraphMetadata
+import app.cash.nostrino.crypto.PubKey
 
 data class FeedUiState(
     val pagingFlow: Flow<PagingData<FeedItem>>,

--- a/features/feeds/screens/src/main/java/social/plasma/features/feeds/screens/threads/ThreadScreenUiState.kt
+++ b/features/feeds/screens/src/main/java/social/plasma/features/feeds/screens/threads/ThreadScreenUiState.kt
@@ -1,11 +1,10 @@
 package social.plasma.features.feeds.screens.threads
 
 import androidx.paging.PagingData
+import app.cash.nostrino.crypto.PubKey
 import com.slack.circuit.CircuitUiState
 import kotlinx.coroutines.flow.Flow
 import social.plasma.features.feeds.screens.feed.FeedItem
-import social.plasma.features.feeds.screens.feed.FeedUiEvent
-import social.plasma.models.PubKey
 import social.plasma.opengraph.OpenGraphMetadata
 
 data class ThreadScreenUiState(

--- a/features/feeds/ui/build.gradle.kts
+++ b/features/feeds/ui/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
 
+    implementation(libs.nostrino)
     implementation(libs.timber)
 
     debugImplementation(libs.compose.ui.test.manifest)

--- a/features/feeds/ui/src/main/java/social/plasma/features/feeds/ui/notes/NoteCard.kt
+++ b/features/feeds/ui/src/main/java/social/plasma/features/feeds/ui/notes/NoteCard.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.unit.dp
 import social.plasma.features.feeds.screens.feed.ContentBlock
 import social.plasma.features.feeds.screens.feed.FeedItem
 import social.plasma.models.NoteId
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.ui.R
 import social.plasma.ui.components.Avatar
 import social.plasma.ui.components.ConfirmationDialog
@@ -479,7 +479,7 @@ object NoteCardFakes {
         replyCount = "352k",
         shareCount = "509k",
         likeCount = 290,
-        userPubkey = PubKey("fdsf")
+        userPubkey = PubKey.parse("npub1jem3jmdve9h94snjkuf5egagk7uupgxtu0eru33mzyms8ctzlk9sjhk73a")
     )
 }
 

--- a/features/feeds/ui/src/test/java/social/plasma/features/feeds/ui/NoteCardTest.kt
+++ b/features/feeds/ui/src/test/java/social/plasma/features/feeds/ui/NoteCardTest.kt
@@ -10,7 +10,8 @@ import org.junit.runner.RunWith
 import social.plasma.features.feeds.screens.feed.ContentBlock
 import social.plasma.features.feeds.screens.feed.FeedItem
 import social.plasma.features.feeds.ui.notes.NoteElevatedCard
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
+import okio.ByteString.Companion.decodeHex
 import social.plasma.ui.testutils.TestDevice
 import social.plasma.ui.testutils.TestFontScale
 import social.plasma.ui.testutils.TestThemeConfig
@@ -29,7 +30,7 @@ enum class NoteCardTestCase(val uiModel: FeedItem.NoteCard) {
             displayName = "Jane",
             id = "",
             content = listOf(ContentBlock.Text("PV", emptyMap())),
-            userPubkey = PubKey("9c9ecd7c8a8c3144ae48bf425b6592c8e53c385fd83376d4ffb7f6ac1a17bfab")
+            userPubkey = PubKey("9c9ecd7c8a8c3144ae48bf425b6592c8e53c385fd83376d4ffb7f6ac1a17bfab".decodeHex())
         )
     )
 }

--- a/features/onboarding/presenters/build.gradle.kts
+++ b/features/onboarding/presenters/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(projects.data.models)
 
     implementation(libs.circuit.core)
+    implementation(libs.nostrino)
     implementation(libs.timber)
 
     implementation(libs.hilt.android)
@@ -66,9 +67,9 @@ dependencies {
     testImplementation(projects.repositories.fakes)
     testImplementation(projects.common.utils.fakes)
     testImplementation(libs.circuit.test)
-    testImplementation(libs.junit)
     testImplementation(libs.coroutines.test)
-    testImplementation(libs.turbine)
+    testImplementation(libs.junit)
     testImplementation(libs.testparameterinjector)
     testImplementation(libs.truth)
+    testImplementation(libs.turbine)
 }

--- a/features/onboarding/presenters/src/main/java/social/plasma/onboarding/presenters/HomePresenter.kt
+++ b/features/onboarding/presenters/src/main/java/social/plasma/onboarding/presenters/HomePresenter.kt
@@ -1,5 +1,6 @@
 package social.plasma.onboarding.presenters
 
+import app.cash.nostrino.crypto.PubKey
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -11,6 +12,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.launch
+import okio.ByteString.Companion.toByteString
 import social.plasma.domain.interactors.SyncAllEvents
 import social.plasma.domain.interactors.SyncProfileData
 import social.plasma.domain.observers.ObserveUserMetadata
@@ -19,7 +21,6 @@ import social.plasma.features.onboarding.screens.home.HomeUiEvent.OnFabClick
 import social.plasma.features.onboarding.screens.home.HomeUiState
 import social.plasma.features.posting.screens.ComposingScreen
 import social.plasma.features.profile.screens.ProfileScreen
-import social.plasma.models.PubKey
 import social.plasma.shared.repositories.api.AccountStateRepository
 
 class HomePresenter @AssistedInject constructor(
@@ -29,7 +30,7 @@ class HomePresenter @AssistedInject constructor(
     accountStateRepository: AccountStateRepository,
     @Assisted private val navigator: Navigator,
 ) : Presenter<HomeUiState> {
-    private val pubKey = PubKey.of(accountStateRepository.getPublicKey()!!)
+    private val pubKey = PubKey(accountStateRepository.getPublicKey()?.toByteString()!!)
     private val metadataFlow = observeMyMetadata.flow
 
     @Composable
@@ -45,7 +46,7 @@ class HomePresenter @AssistedInject constructor(
         return HomeUiState(avatarUrl = metadata?.picture) { event ->
             when (event) {
                 OnFabClick -> navigator.goTo(ComposingScreen())
-                HomeUiEvent.OnAvatarClick -> navigator.goTo(ProfileScreen(pubKeyHex = pubKey.hex))
+                HomeUiEvent.OnAvatarClick -> navigator.goTo(ProfileScreen(pubKeyHex = pubKey.key.hex()))
                 is HomeUiEvent.OnChildNav -> navigator.onNavEvent(event.navEvent)
             }
         }

--- a/features/posting/presenters/build.gradle.kts
+++ b/features/posting/presenters/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(projects.repositories.api)
 
     implementation(libs.circuit.core)
+    implementation(libs.nostrino)
 
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)

--- a/features/posting/presenters/src/main/kotlin/social/plasma/features/posting/presenters/ComposingScreenPresenter.kt
+++ b/features/posting/presenters/src/main/kotlin/social/plasma/features/posting/presenters/ComposingScreenPresenter.kt
@@ -176,7 +176,7 @@ class ComposingScreenPresenter @AssistedInject constructor(
                         text = "@${event.suggestion.title}",
                         pubkey = event.suggestion.pubKey,
                     )
-                    val replacement = "@${profileMention.pubkey.bech32}"
+                    val replacement = "@${profileMention.pubkey.npub}"
 
                     mentions[replacement] = profileMention
 

--- a/features/posting/presenters/src/test/kotlin/social/plasma/features/posting/presenters/ComposingScreenPresenterTest.kt
+++ b/features/posting/presenters/src/test/kotlin/social/plasma/features/posting/presenters/ComposingScreenPresenterTest.kt
@@ -17,7 +17,8 @@ import social.plasma.features.posting.screens.ComposePostUiEvent.OnNoteChange
 import social.plasma.features.posting.screens.ComposePostUiEvent.OnSubmitPost
 import social.plasma.features.posting.screens.ComposePostUiEvent.OnSuggestionTapped
 import social.plasma.features.posting.screens.ComposingScreen
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
+import okio.ByteString.Companion.decodeHex
 import social.plasma.models.TagSuggestion
 import social.plasma.models.UserMetadataEntity
 import social.plasma.shared.repositories.fakes.FakeNip5Validator
@@ -176,7 +177,7 @@ class ComposingScreenPresenterTest {
             awaitItem()
 
             with(awaitItem()) {
-                assertThat(noteContent.text).isEqualTo("@${pubKey.bech32} ")
+                assertThat(noteContent.text).isEqualTo("@${pubKey.encoded()} ")
             }
 
         }
@@ -196,7 +197,7 @@ class ComposingScreenPresenterTest {
     )
 
     companion object {
-        val pubKey = PubKey("9c9ecd7c8a8c3144ae48bf425b6592c8e53c385fd83376d4ffb7f6ac1a17bfab")
+        val pubKey = PubKey("9c9ecd7c8a8c3144ae48bf425b6592c8e53c385fd83376d4ffb7f6ac1a17bfab".decodeHex())
     }
 }
 

--- a/features/posting/ui/build.gradle.kts
+++ b/features/posting/ui/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
 
+    implementation(libs.nostrino)
     implementation(libs.timber)
 
     debugImplementation(libs.compose.ui.test.manifest)

--- a/features/posting/ui/src/main/java/social/plasma/features/posting/ui/composepost/MentionsVisualTransformation.kt
+++ b/features/posting/ui/src/main/java/social/plasma/features/posting/ui/composepost/MentionsVisualTransformation.kt
@@ -13,7 +13,7 @@ class MentionsVisualTransformation constructor(
     private val highlightColor: Color,
     private val mentions: Map<String, ProfileMention>,
 ) : VisualTransformation {
-    private val bech32Regex = Regex("(@npub)[0-9a-z]{1,83}")
+    private val bech32Regex = Regex("(@npub)[\\da-z]{1,83}")
 
     override fun filter(text: AnnotatedString): TransformedText {
         val (transformedText, offsetMapping) = replaceMentions(text)
@@ -49,7 +49,8 @@ class MentionsVisualTransformation constructor(
                             transformedWord += textBefore
                         }
 
-                        withProfileMention(mention.pubkey.hex, highlightColor) {
+                        // TODO replace .key.hex() with .hex() everywhere when nostrino is updated
+                        withProfileMention(mention.pubkey.key.hex(), highlightColor) {
                             append(mention.text)
                             transformedWord += mention.text
                         }

--- a/features/posting/ui/src/test/java/social/plasma/features/posting/ui/composepost/ComposePostUiTest.kt
+++ b/features/posting/ui/src/test/java/social/plasma/features/posting/ui/composepost/ComposePostUiTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import social.plasma.features.posting.screens.AutoCompleteSuggestion
 import social.plasma.features.posting.screens.ComposePostUiState
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.models.TagSuggestion
 import social.plasma.ui.testutils.TestDevice
 import social.plasma.ui.testutils.TestFontScale
@@ -67,7 +67,7 @@ class ComposePostUiTest constructor(
                 autoCompleteSuggestions = listOf(
                     AutoCompleteSuggestion(
                         TagSuggestion(
-                            pubKey = PubKey("1"),
+                            pubKey = PubKey.parse("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"),
                             imageUrl = null,
                             title = "KoalaSat",
                             nip5Identifier = "koalasat@nostros.net",
@@ -75,7 +75,7 @@ class ComposePostUiTest constructor(
                     ),
                     AutoCompleteSuggestion(
                         TagSuggestion(
-                            pubKey = PubKey("1"),
+                            pubKey = PubKey.parse("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"),
                             imageUrl = null,
                             title = "KoalaSat",
                             nip5Identifier = "koalasat@nostros.net",
@@ -83,7 +83,7 @@ class ComposePostUiTest constructor(
                     ),
                     AutoCompleteSuggestion(
                         TagSuggestion(
-                            pubKey = PubKey("1"),
+                            pubKey = PubKey.parse("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"),
                             imageUrl = null,
                             title = "KoalaSat",
                             nip5Identifier = "koalasat@nostros.net",

--- a/features/posting/ui/src/test/java/social/plasma/features/posting/ui/composepost/MentionsVisualTransformationTest.kt
+++ b/features/posting/ui/src/test/java/social/plasma/features/posting/ui/composepost/MentionsVisualTransformationTest.kt
@@ -5,8 +5,7 @@ import androidx.compose.ui.text.AnnotatedString
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import social.plasma.models.ProfileMention
-import social.plasma.models.PubKey
-import social.plasma.models.crypto.Bech32.bechToBytes
+import app.cash.nostrino.crypto.PubKey
 
 
 class MentionsVisualTransformationTest {
@@ -72,7 +71,7 @@ class MentionsVisualTransformationTest {
 
     companion object {
         val pubKey =
-            PubKey.of("npub1z2aauyjavy9kfau3jn4cq3u0uvadjhkngxzv0uzh0e3pfuexdjcql0pyy7".bechToBytes())
+            PubKey.parse("npub1z2aauyjavy9kfau3jn4cq3u0uvadjhkngxzv0uzh0e3pfuexdjcql0pyy7")
         const val npubString = "@npub1z2aauyjavy9kfau3jn4cq3u0uvadjhkngxzv0uzh0e3pfuexdjcql0pyy7"
     }
 }

--- a/features/profile/presenters/build.gradle.kts
+++ b/features/profile/presenters/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(libs.androidx.paging.common)
     implementation(libs.circuit.core)
     implementation(libs.circuit.retained)
+    implementation(libs.nostrino)
     implementation(libs.timber)
 
     implementation(libs.hilt.android)

--- a/features/profile/presenters/src/main/java/social/plasma/profile/presenters/ProfileScreenPresenter.kt
+++ b/features/profile/presenters/src/main/java/social/plasma/profile/presenters/ProfileScreenPresenter.kt
@@ -27,8 +27,11 @@ import social.plasma.features.profile.screens.ProfileUiEvent
 import social.plasma.features.profile.screens.ProfileUiState
 import social.plasma.features.profile.screens.ProfileUiState.Loaded.ProfileStat
 import social.plasma.feeds.presenters.feed.FeedPresenter
-import social.plasma.models.PubKey
 import social.plasma.shared.repositories.api.AccountStateRepository
+import app.cash.nostrino.crypto.PubKey
+import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.toByteString
+import shortBech32
 
 class ProfileScreenPresenter @AssistedInject constructor(
     private val observeFollowingCount: ObserveFollowingCount,
@@ -42,8 +45,8 @@ class ProfileScreenPresenter @AssistedInject constructor(
     @Assisted private val args: ProfileScreen,
     @Assisted private val navigator: Navigator,
 ) : Presenter<ProfileUiState> {
-    private val myPubKey = PubKey.of(accountStateRepository.getPublicKey()!!)
-    private val pubKey = PubKey(args.pubKeyHex)
+    private val myPubKey = PubKey(accountStateRepository.getPublicKey()?.toByteString()!!)
+    private val pubKey = PubKey(args.pubKeyHex.decodeHex())
 
     private val metadataInitialState =
         ProfileUiState.Loaded.UserData(
@@ -106,7 +109,7 @@ class ProfileScreenPresenter @AssistedInject constructor(
         val userData by produceState(initialValue = metadataInitialState, metadata) {
             metadata?.let {
                 value = ProfileUiState.Loaded.UserData(
-                    petName = metadata!!.displayName ?: pubKey.shortBech32,
+                    petName = metadata!!.displayName ?: pubKey.shortBech32(),
                     banner = metadata!!.banner
                         ?: "https://pbs.twimg.com/media/FnbPBoKWYAAc0-F?format=jpg&name=4096x4096",
                     website = metadata!!.website,

--- a/features/profile/screens/build.gradle.kts
+++ b/features/profile/screens/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(projects.data.models)
     implementation(libs.circuit.core)
     implementation(libs.compose.runtime)
+    implementation(libs.nostrino)
 
     implementation(libs.androidx.paging.runtime)
 }

--- a/features/profile/screens/src/main/java/social/plasma/features/profile/screens/ProfileUiState.kt
+++ b/features/profile/screens/src/main/java/social/plasma/features/profile/screens/ProfileUiState.kt
@@ -1,11 +1,8 @@
 package social.plasma.features.profile.screens
 
-import androidx.paging.PagingData
 import com.slack.circuit.CircuitUiState
-import kotlinx.coroutines.flow.Flow
-import social.plasma.features.feeds.screens.feed.FeedItem
 import social.plasma.features.feeds.screens.feed.FeedUiState
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 
 sealed interface ProfileUiState : CircuitUiState {
     object Loading : ProfileUiState

--- a/features/profile/ui/build.gradle.kts
+++ b/features/profile/ui/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation(libs.hilt.android)
     kapt(libs.hilt.compiler)
 
+    implementation(libs.nostrino)
     implementation(libs.timber)
 
     debugImplementation(libs.compose.ui.test.manifest)

--- a/features/profile/ui/src/main/java/social/plasma/features/profile/ui/ProfileScreenUi.kt
+++ b/features/profile/ui/src/main/java/social/plasma/features/profile/ui/ProfileScreenUi.kt
@@ -63,7 +63,7 @@ import social.plasma.features.profile.screens.ProfileUiEvent.OnNavigateBack
 import social.plasma.features.profile.screens.ProfileUiState
 import social.plasma.features.profile.screens.ProfileUiState.Loaded
 import social.plasma.features.profile.screens.ProfileUiState.Loading
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.ui.R
 import social.plasma.ui.components.ConfirmationDialog
 import social.plasma.ui.components.Nip5Badge
@@ -221,7 +221,7 @@ class ProfileScreenUi @Inject constructor(
 
         OverlayIconButton(
             onClick = {
-                clipboardManager.setText(AnnotatedString(pubKey.bech32))
+                clipboardManager.setText(AnnotatedString(pubKey.encoded()))
             }
         ) {
             Icon(
@@ -392,7 +392,7 @@ class ProfilePreviewProvider : PreviewParameterProvider<ProfileUiState> {
                 nip5Identifier = nip5,
                 petName = "Satoshi",
                 username = username,
-                publicKey = PubKey(UUID.randomUUID().toString()),
+                publicKey = PubKey.parse("npub1jem3jmdve9h94snjkuf5egagk7uupgxtu0eru33mzyms8ctzlk9sjhk73a"),
                 about = "Developer @ a peer-to-peer electronic cash system",
                 avatarUrl = "https://api.dicebear.com/5.x/bottts/jpg",
                 website = "https://cash.app",

--- a/features/profile/ui/src/test/java/social/plasma/features/profile/ui/ProfileScreenUiTest.kt
+++ b/features/profile/ui/src/test/java/social/plasma/features/profile/ui/ProfileScreenUiTest.kt
@@ -14,7 +14,7 @@ import social.plasma.features.feeds.screens.feed.FeedItem
 import social.plasma.features.feeds.screens.feed.FeedUiState
 import social.plasma.features.feeds.ui.FeedUi
 import social.plasma.features.profile.screens.ProfileUiState
-import social.plasma.models.PubKey
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.ui.testutils.TestDevice
 import social.plasma.ui.testutils.TestFontScale
 import social.plasma.ui.testutils.TestThemeConfig
@@ -60,7 +60,7 @@ private class ProfileTestCaseProvider : TestParameter.TestParameterValuesProvide
             website = "https://plasma.social",
             petName = "Plasma",
             username = "@plasma",
-            publicKey = PubKey(""),
+            publicKey = PubKey.parse("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"),
             about = "A native nostr client for Android",
             avatarUrl = "https://api.dicebear.com/5.x/big-smile/png?seed=plasma",
             nip5Identifier = "_@plasma.social",
@@ -97,7 +97,7 @@ private class ProfileTestCaseProvider : TestParameter.TestParameterValuesProvide
                 replyCount = "55",
                 shareCount = "500",
                 likeCount = 400,
-                userPubkey = PubKey(""),
+                userPubkey = PubKey.parse("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"),
                 isLiked = true,
                 isNip5Valid = { _, _ -> true },
                 nip5Domain = userData.nip5Domain,

--- a/repositories/api/build.gradle.kts
+++ b/repositories/api/build.gradle.kts
@@ -41,4 +41,5 @@ dependencies {
     implementation(projects.data.models)
     api(libs.androidx.paging.common)
     implementation(libs.coroutines.android)
+    implementation(libs.nostrino)
 }

--- a/repositories/api/src/main/java/social/plasma/shared/repositories/api/NoteRepository.kt
+++ b/repositories/api/src/main/java/social/plasma/shared/repositories/api/NoteRepository.kt
@@ -1,9 +1,9 @@
 package social.plasma.shared.repositories.api
 
 import androidx.paging.PagingSource
+import app.cash.nostrino.crypto.PubKey
 import social.plasma.models.NoteId
 import social.plasma.models.NoteWithUser
-import social.plasma.models.PubKey
 import social.plasma.models.Tag
 
 interface NoteRepository {

--- a/repositories/api/src/main/java/social/plasma/shared/repositories/api/UserMetadataRepository.kt
+++ b/repositories/api/src/main/java/social/plasma/shared/repositories/api/UserMetadataRepository.kt
@@ -1,7 +1,7 @@
 package social.plasma.shared.repositories.api
 
+import app.cash.nostrino.crypto.PubKey
 import kotlinx.coroutines.flow.Flow
-import social.plasma.models.PubKey
 import social.plasma.models.UserMetadataEntity
 
 

--- a/repositories/fakes/build.gradle.kts
+++ b/repositories/fakes/build.gradle.kts
@@ -41,5 +41,6 @@ dependencies {
     api(projects.repositories.api)
 
     implementation(projects.data.models)
+    implementation(libs.nostrino)
     implementation(libs.turbine)
 }

--- a/repositories/fakes/src/main/kotlin/social/plasma/shared/repositories/fakes/FakeNoteRepository.kt
+++ b/repositories/fakes/src/main/kotlin/social/plasma/shared/repositories/fakes/FakeNoteRepository.kt
@@ -1,12 +1,12 @@
 package social.plasma.shared.repositories.fakes
 
 import androidx.paging.PagingSource
+import app.cash.nostrino.crypto.PubKey
 import app.cash.turbine.Turbine
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.getAndUpdate
 import social.plasma.models.NoteId
 import social.plasma.models.NoteWithUser
-import social.plasma.models.PubKey
 import social.plasma.models.Tag
 import social.plasma.shared.repositories.api.NoteRepository
 

--- a/repositories/fakes/src/main/kotlin/social/plasma/shared/repositories/fakes/FakeUserMetadataRepository.kt
+++ b/repositories/fakes/src/main/kotlin/social/plasma/shared/repositories/fakes/FakeUserMetadataRepository.kt
@@ -1,8 +1,8 @@
 package social.plasma.shared.repositories.fakes
 
+import app.cash.nostrino.crypto.PubKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
-import social.plasma.models.PubKey
 import social.plasma.models.UserMetadataEntity
 import social.plasma.shared.repositories.api.UserMetadataRepository
 

--- a/repositories/real/src/main/kotlin/social/plasma/shared/repositories/real/RealNoteRepository.kt
+++ b/repositories/real/src/main/kotlin/social/plasma/shared/repositories/real/RealNoteRepository.kt
@@ -1,20 +1,16 @@
 package social.plasma.shared.repositories.real
 
 import androidx.paging.PagingSource
+import app.cash.nostrino.crypto.PubKey
 import okio.ByteString.Companion.toByteString
 import social.plasma.data.daos.NotesDao
-import social.plasma.models.EventTag
-import social.plasma.models.NoteId
-import social.plasma.models.NoteWithUser
-import social.plasma.models.PubKey
-import social.plasma.models.PubKeyTag
-import social.plasma.models.Tag
 import social.plasma.models.crypto.KeyPair
 import social.plasma.nostr.relay.Relay
 import social.plasma.shared.repositories.api.AccountStateRepository
 import social.plasma.shared.repositories.api.NoteRepository
 import javax.inject.Inject
 import app.cash.nostrino.crypto.SecKey
+import social.plasma.models.*
 
 internal class RealNoteRepository @Inject constructor(
     private val relay: Relay,
@@ -29,7 +25,7 @@ internal class RealNoteRepository @Inject constructor(
         val nostrTags = tags.map { tag ->
             when (tag) {
                 is EventTag -> listOf("e", tag.noteId.hex)
-                is PubKeyTag -> listOf("p", tag.pubKey.hex)
+                is PubKeyTag -> listOf("p", tag.pubKey.key.hex())
             }
         }.toSet()
 
@@ -44,25 +40,25 @@ internal class RealNoteRepository @Inject constructor(
     }
 
     override fun observePagedContactsNotes(): PagingSource<Int, NoteWithUser> {
-        val pubkey = PubKey.of(accountStateRepository.getPublicKey()!!)
+        val pubkey = PubKey(accountStateRepository.getPublicKey()?.toByteString()!!)
 
-        return notesDao.observePagedContactsNotes(pubkey.hex)
+        return notesDao.observePagedContactsNotes(pubkey.key.hex())
     }
 
     override fun observePagedNotifications(): PagingSource<Int, NoteWithUser> {
-        val pubkey = PubKey.of(accountStateRepository.getPublicKey()!!)
+        val pubkey = PubKey(accountStateRepository.getPublicKey()?.toByteString()!!)
 
-        return notesDao.observePagedNotifications(pubkey.hex)
+        return notesDao.observePagedNotifications(pubkey.key.hex())
     }
 
     override fun observePagedContactsReplies(): PagingSource<Int, NoteWithUser> {
-        val pubkey = PubKey.of(accountStateRepository.getPublicKey()!!)
+        val pubkey = PubKey(accountStateRepository.getPublicKey()?.toByteString()!!)
 
-       return notesDao.observePagedContactsReplies(pubkey.hex)
+       return notesDao.observePagedContactsReplies(pubkey.key.hex())
     }
 
     override fun observePagedUserNotes(pubKey: PubKey): PagingSource<Int, NoteWithUser> {
-        return notesDao.observePagedUserNotes(pubKey.hex)
+        return notesDao.observePagedUserNotes(pubKey.key.hex())
     }
 
     override fun observePagedThreadNotes(noteId: NoteId): PagingSource<Int, NoteWithUser> {
@@ -75,6 +71,6 @@ internal class RealNoteRepository @Inject constructor(
     }
 
     override suspend fun isNoteLiked(byPubKey: PubKey, noteId: NoteId): Boolean {
-        return notesDao.isNoteLiked(byPubKey.hex, noteId.hex)
+        return notesDao.isNoteLiked(byPubKey.key.hex(), noteId.hex)
     }
 }

--- a/repositories/real/src/main/kotlin/social/plasma/shared/repositories/real/RealUserMetadataRepository.kt
+++ b/repositories/real/src/main/kotlin/social/plasma/shared/repositories/real/RealUserMetadataRepository.kt
@@ -1,8 +1,8 @@
 package social.plasma.shared.repositories.real
 
+import app.cash.nostrino.crypto.PubKey
 import kotlinx.coroutines.flow.Flow
 import social.plasma.data.daos.UserMetadataDao
-import social.plasma.models.PubKey
 import social.plasma.models.UserMetadataEntity
 import social.plasma.shared.repositories.api.UserMetadataRepository
 import javax.inject.Inject
@@ -11,7 +11,7 @@ internal class RealUserMetadataRepository @Inject constructor(
     private val userMetadataDao: UserMetadataDao,
 ) : UserMetadataRepository {
     override fun observeUserMetaData(pubKey: PubKey): Flow<UserMetadataEntity?> {
-        return userMetadataDao.observeUserMetadata(pubKey.hex)
+        return userMetadataDao.observeUserMetadata(pubKey.key.hex())
     }
 
     override suspend fun searchUsers(query: String): List<UserMetadataEntity> {


### PR DESCRIPTION
Removes the baked in `PubKey` type any uses the one from Nostrino instead.
This type is more strict, so several tests needed to be changed to use real keys instead of dummy text.
